### PR TITLE
Make PathReader class and initializer public

### DIFF
--- a/Source/Parser/SVG/SVGPathReader.swift
+++ b/Source/Parser/SVG/SVGPathReader.swift
@@ -59,14 +59,14 @@ public class PathSegment {
     }
 }
 
-class PathReader {
+public class PathReader {
 
     private let input: String
     private var current: UnicodeScalar?
     private var previous: UnicodeScalar?
     private var iterator: String.UnicodeScalarView.Iterator
 
-    init(input: String) {
+    public init(input: String) {
         self.input = input
         self.iterator = input.unicodeScalars.makeIterator()
     }


### PR DESCRIPTION
This change makes the PathReader class and its initializer public needed for https://github.com/GoodNotes/GoodNotes-5/pull/44908