### PR TITLE
Fix matrix concat order in polyfill

### DIFF
--- a/Source/CoreGraphicsPolyfill.swift
+++ b/Source/CoreGraphicsPolyfill.swift
@@ -316,12 +316,12 @@ import Foundation
 
         public func concatenating(_ t: CGAffineTransform) -> CGAffineTransform {
             return CGAffineTransform(
-                a: a * t.a + c * t.b,
-                b: b * t.a + d * t.b,
-                c: a * t.c + c * t.d,
-                d: b * t.c + d * t.d,
-                tx: a * t.tx + c * t.ty + tx,
-                ty: b * t.tx + d * t.ty + ty
+                a: a * t.a + b * t.c,
+                b: a * t.b + b * t.d,
+                c: c * t.a + d * t.c,
+                d: c * t.b + d * t.d,
+                tx: tx * t.a + ty * t.c + t.tx,
+                ty: tx * t.b + ty * t.d + t.ty
             )
         }
 

--- a/Tests/CoreGraphicsPolyfillTests/PolyfillTests.swift
+++ b/Tests/CoreGraphicsPolyfillTests/PolyfillTests.swift
@@ -84,8 +84,8 @@ final class PolyfillTests: XCTestCase {
         
         XCTAssertEqual(combined.a, 2)
         XCTAssertEqual(combined.d, 3)
-        XCTAssertEqual(combined.tx, 5)
-        XCTAssertEqual(combined.ty, 10)
+        XCTAssertEqual(combined.tx, 10)
+        XCTAssertEqual(combined.ty, 30)
     }
     
     func testTransformFluent() {

--- a/Tests/SVGViewTests/CGTests.swift
+++ b/Tests/SVGViewTests/CGTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import SVGView
+
+class CGTests: BaseTestCase {
+
+    func testTransformConcatenation() {
+        let transform1 = CGAffineTransform(translationX: 5, y: 10)
+        let transform2 = CGAffineTransform(scaleX: 2, y: 3)
+        let combined = transform1.concatenating(transform2)
+        
+        XCTAssertEqual(combined.a, 2)
+        XCTAssertEqual(combined.d, 3)
+        XCTAssertEqual(combined.tx, 10)
+        XCTAssertEqual(combined.ty, 30)
+    }
+
+}


### PR DESCRIPTION
The matrix concat operation was doing `B . A` for `A.concatenating(B)` which was causing issues when combining transformations.