### PR TITLE
feat: enable CoreGraphics polyfill on Android

### DIFF
--- a/Source/CoreGraphicsPolyfill.swift
+++ b/Source/CoreGraphicsPolyfill.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
     private let KAPPA: CGFloat = 0.5522847498  // 4 *(sqrt(2) -1)/3
 
     public struct CGAffineTransform: Equatable {

--- a/Source/Model/Images/SVGDataImage.swift
+++ b/Source/Model/Images/SVGDataImage.swift
@@ -5,7 +5,7 @@
 //  Created by Alisa Mylnikova on 10/06/2021.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI
@@ -13,7 +13,7 @@ import Combine
 #endif
 
 public class SVGDataImage: SVGImage {
-    #if os(WASI) || os(Linux)           
+    #if os(WASI) || os(Linux) || os(Android)           
     public var data: Data
     #else
     @Published public var data: Data

--- a/Source/Model/Images/SVGURLImage.swift
+++ b/Source/Model/Images/SVGURLImage.swift
@@ -5,7 +5,7 @@
 //  Created by Alisa Mylnikova on 22/09/2021.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/Model/Nodes/SVGDefs.swift
+++ b/Source/Model/Nodes/SVGDefs.swift
@@ -1,4 +1,4 @@
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/Model/Nodes/SVGGroup.swift
+++ b/Source/Model/Nodes/SVGGroup.swift
@@ -1,4 +1,4 @@
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI
@@ -6,7 +6,7 @@ import Combine
 #endif
 
 public class SVGGroup: SVGNode {
-    #if os(WASI) || os(Linux)
+    #if os(WASI) || os(Linux) || os(Android)
     public var contents: [SVGNode] = []
     #else
     @Published public var contents: [SVGNode] = []

--- a/Source/Model/Nodes/SVGImage.swift
+++ b/Source/Model/Nodes/SVGImage.swift
@@ -5,7 +5,7 @@
 //  Created by Alisa Mylnikova on 03/06/2021.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI
@@ -14,7 +14,7 @@ import Combine
 
 public class SVGImage: SVGNode {
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
     public var x: CGFloat
     public var y: CGFloat
     public var width: CGFloat

--- a/Source/Model/Nodes/SVGMarker.swift
+++ b/Source/Model/Nodes/SVGMarker.swift
@@ -1,4 +1,4 @@
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI
@@ -60,7 +60,7 @@ public class SVGMarker: SVGGroup {
         case strokeWidth
     }
 
-    #if os(WASI) || os(Linux)
+    #if os(WASI) || os(Linux) || os(Android)
     public var markerHeight: SVGLength
     public var markerUnits: MarkerUnits
     public var markerWidth: SVGLength

--- a/Source/Model/Nodes/SVGNode.swift
+++ b/Source/Model/Nodes/SVGNode.swift
@@ -1,4 +1,4 @@
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI
@@ -7,7 +7,7 @@ import Combine
 
 public class SVGNode: SerializableElement {
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
     public var transform: CGAffineTransform = CGAffineTransform.identity
     public var opaque: Bool
     public var opacity: Double

--- a/Source/Model/Nodes/SVGShape.swift
+++ b/Source/Model/Nodes/SVGShape.swift
@@ -1,4 +1,4 @@
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI
@@ -7,7 +7,7 @@ import Combine
 
 public class SVGShape: SVGNode {
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
     public var fill: SVGPaint?
     public var stroke: SVGStroke?
 #else

--- a/Source/Model/Nodes/SVGText.swift
+++ b/Source/Model/Nodes/SVGText.swift
@@ -1,4 +1,4 @@
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI
@@ -12,7 +12,7 @@ public class SVGText: SVGNode {
         case trailing
     }
     
-    #if os(WASI) || os(Linux)
+    #if os(WASI) || os(Linux) || os(Android)
     public var text: String
     public var font: SVGFont?
     public var fill: SVGPaint?

--- a/Source/Model/Nodes/SVGUserSpaceNode.swift
+++ b/Source/Model/Nodes/SVGUserSpaceNode.swift
@@ -5,7 +5,7 @@
 //  Created by Alisa Mylnikova on 14/10/2020.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/Model/Nodes/SVGViewport.swift
+++ b/Source/Model/Nodes/SVGViewport.swift
@@ -1,4 +1,4 @@
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI
@@ -6,7 +6,7 @@ import Combine
 #endif
 
 public class SVGViewport: SVGGroup {
-    #if os(WASI) || os(Linux)
+    #if os(WASI) || os(Linux) || os(Android)
     public var width: SVGLength
     public var height: SVGLength
     public var viewBox: CGRect?

--- a/Source/Model/Primitives/SVGColor.swift
+++ b/Source/Model/Primitives/SVGColor.swift
@@ -5,7 +5,7 @@
 //  Created by Yuriy Strot on 19.01.2021.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/Model/Primitives/SVGFont.swift
+++ b/Source/Model/Primitives/SVGFont.swift
@@ -1,4 +1,4 @@
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/Model/Primitives/SVGGradient.swift
+++ b/Source/Model/Primitives/SVGGradient.swift
@@ -5,7 +5,7 @@
 //  Created by Yuriy Strot on 22.02.2021.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/Model/Primitives/SVGLength.swift
+++ b/Source/Model/Primitives/SVGLength.swift
@@ -5,7 +5,7 @@
 //  Created by Alisa Mylnikova on 13/10/2020.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/Model/Primitives/SVGPaint.swift
+++ b/Source/Model/Primitives/SVGPaint.swift
@@ -5,7 +5,7 @@
 //  Created by Yuriy Strot on 19.01.2021.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/Model/Primitives/SVGPreserveAspectRatio.swift
+++ b/Source/Model/Primitives/SVGPreserveAspectRatio.swift
@@ -5,7 +5,7 @@
 //  Created by Yuriy Strot on 20.01.2021.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/Model/Primitives/SVGStroke.swift
+++ b/Source/Model/Primitives/SVGStroke.swift
@@ -1,4 +1,4 @@
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/Model/Shapes/SVGCircle.swift
+++ b/Source/Model/Shapes/SVGCircle.swift
@@ -1,4 +1,4 @@
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI
@@ -7,7 +7,7 @@ import Combine
 
 public class SVGCircle: SVGShape {
 
-    #if os(WASI) || os(Linux)
+    #if os(WASI) || os(Linux) || os(Android)
     public var cx: CGFloat
     public var cy: CGFloat
     public var r: CGFloat

--- a/Source/Model/Shapes/SVGEllipse.swift
+++ b/Source/Model/Shapes/SVGEllipse.swift
@@ -1,4 +1,4 @@
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI
@@ -6,7 +6,7 @@ import Combine
 #endif
 
 public class SVGEllipse: SVGShape {
-    #if os(WASI) || os(Linux)
+    #if os(WASI) || os(Linux) || os(Android)
     public var cx: CGFloat
     public var cy: CGFloat
     public var rx: CGFloat

--- a/Source/Model/Shapes/SVGLine.swift
+++ b/Source/Model/Shapes/SVGLine.swift
@@ -1,4 +1,4 @@
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI
@@ -7,7 +7,7 @@ import Combine
 
 public class SVGLine: SVGShape {
 
-    #if os(WASI) || os(Linux)
+    #if os(WASI) || os(Linux) || os(Android)
     public var x1: CGFloat
     public var y1: CGFloat
     public var x2: CGFloat

--- a/Source/Model/Shapes/SVGPath.swift
+++ b/Source/Model/Shapes/SVGPath.swift
@@ -1,4 +1,4 @@
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI
@@ -7,7 +7,7 @@ import Combine
 
 public class SVGPath: SVGShape {
 
-    #if os(WASI) || os(Linux)
+    #if os(WASI) || os(Linux) || os(Android)
     public var segments: [PathSegment]
     public var fillRule: CGPathFillRule
     #else

--- a/Source/Model/Shapes/SVGPolygon.swift
+++ b/Source/Model/Shapes/SVGPolygon.swift
@@ -1,4 +1,4 @@
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI
@@ -7,7 +7,7 @@ import Combine
 
 public class SVGPolygon: SVGShape {
 
-    #if os(WASI) || os(Linux)
+    #if os(WASI) || os(Linux) || os(Android)
     public var points: [CGPoint]
     #else
     @Published public var points: [CGPoint]

--- a/Source/Model/Shapes/SVGPolyline.swift
+++ b/Source/Model/Shapes/SVGPolyline.swift
@@ -1,4 +1,4 @@
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI
@@ -6,7 +6,7 @@ import Combine
 #endif
 
 public class SVGPolyline: SVGShape {
-    #if os(WASI) || os(Linux)
+    #if os(WASI) || os(Linux) || os(Android)
     public var points: [CGPoint]
     #else
     @Published public var points: [CGPoint]

--- a/Source/Model/Shapes/SVGRect.swift
+++ b/Source/Model/Shapes/SVGRect.swift
@@ -1,4 +1,4 @@
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI
@@ -7,7 +7,7 @@ import Combine
 
 public class SVGRect: SVGShape {
 
-    #if os(WASI) || os(Linux)
+    #if os(WASI) || os(Linux) || os(Android)
     public var x: CGFloat
     public var y: CGFloat
     public var width: CGFloat

--- a/Source/Parser/SVG/Elements/SVGImageParser.swift
+++ b/Source/Parser/SVG/Elements/SVGImageParser.swift
@@ -5,7 +5,7 @@
 //  Created by Yuri Strot on 29.05.2022.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/Parser/SVG/Elements/SVGTextParser.swift
+++ b/Source/Parser/SVG/Elements/SVGTextParser.swift
@@ -5,7 +5,7 @@
 //  Created by Yuri Strot on 29.05.2022.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/Parser/SVG/SVGIndex.swift
+++ b/Source/Parser/SVG/SVGIndex.swift
@@ -5,7 +5,7 @@
 //  Created by Yuriy Strot on 21.02.2021.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/Parser/SVG/SVGParserBasics.swift
+++ b/Source/Parser/SVG/SVGParserBasics.swift
@@ -5,7 +5,7 @@
 //  Created by Alisa Mylnikova on 17/07/2020.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/Parser/SVG/SVGParserPrimitives.swift
+++ b/Source/Parser/SVG/SVGParserPrimitives.swift
@@ -5,7 +5,7 @@
 //  Created by Alisa Mylnikova on 20/07/2020.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/Parser/SVG/SVGPathReader.swift
+++ b/Source/Parser/SVG/SVGPathReader.swift
@@ -11,7 +11,7 @@ public typealias MBezierPath = NSBezierPath
 #elseif os(iOS) || os(tvOS) || os(watchOS)
 import UIKit
 public typealias MBezierPath = UIBezierPath
-#elseif os(WASI) || os(Linux)
+#elseif os(WASI) || os(Linux) || os(Android)
 import Foundation
 #endif
 
@@ -336,7 +336,7 @@ extension SVGPath {
             return CGFloat > 0.5 ? true : false
         }
 
-        #if os(WASI) || os(Linux)
+        #if os(WASI) || os(Linux) || os(Android)
         var bezierPath = MBezierPath()
         #else
         let bezierPath = MBezierPath()
@@ -565,7 +565,7 @@ extension SVGPath {
                 bezierPath.addArc(withCenter: CGPoint(x: cx, y: cy), radius: CGFloat(w / 2), startAngle: extent, endAngle: end, clockwise: arcAngle >= 0)
             } else {
                 let maxSize = CGFloat(max(w, h))
-                #if os(WASI) || os(Linux)
+                #if os(WASI) || os(Linux) || os(Android)
                 var path = MBezierPath(arcCenter: CGPoint.zero, radius: maxSize / 2, startAngle: extent, endAngle: end, clockwise: arcAngle >= 0)
                 #else
                 let path = MBezierPath(arcCenter: CGPoint.zero, radius: maxSize / 2, startAngle: extent, endAngle: end, clockwise: arcAngle >= 0)

--- a/Source/Parser/SVG/SVGView.swift
+++ b/Source/Parser/SVG/SVGView.swift
@@ -5,7 +5,7 @@
 //  Created by Alisa Mylnikova on 20/08/2020.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/Parser/XML/DOMParser.swift
+++ b/Source/Parser/XML/DOMParser.swift
@@ -5,7 +5,7 @@
 //  Created by Alisa Mylnikova on 20/08/2020.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 import FoundationXML
 #else

--- a/Source/Parser/XML/XMLNode.swift
+++ b/Source/Parser/XML/XMLNode.swift
@@ -1,4 +1,4 @@
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/Serialization/Serializations.swift
+++ b/Source/Serialization/Serializations.swift
@@ -5,7 +5,7 @@
 //  Created by Yuriy Strot on 18.01.2021.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Source/UI/UIExtensions.swift
+++ b/Source/UI/UIExtensions.swift
@@ -5,7 +5,7 @@
 //  Created by Yuri Strot on 25.05.2022.
 //
 
-#if os(WASI) || os(Linux)
+#if os(WASI) || os(Linux) || os(Android)
 import Foundation
 #else
 import SwiftUI

--- a/Tests/CoreGraphicsPolyfillTests/PolyfillTests.swift
+++ b/Tests/CoreGraphicsPolyfillTests/PolyfillTests.swift
@@ -22,7 +22,7 @@ import XCTest
 
 final class PolyfillTests: XCTestCase {
     
-    #if os(WASI) || os(Linux)
+    #if os(WASI) || os(Linux) || os(Android)
     
     // MARK: - CGAffineTransform Tests
     


### PR DESCRIPTION
## Summary

Extends every `#if os(WASI) || os(Linux)` gate in `Source/` and `Tests/` to also include `os(Android)` so the pure-Swift CoreGraphics polyfill is selected on Android. The polyfill is Foundation-only — no platform-specific code — so the same path that's been working for WASI/Linux works on Android with no further changes.

Why: downstream packages (`GoodNotes/CanvasKit`'s `SVGToNotesItems`, `CommonNLI`'s SVG conversion) need this to build on Android. Until now, anywhere that imports `SVGToNotesItems` either had to `#if canImport(SVGToNotesItems)` guard the call site or exclude itself from the Android build graph.

Tagged as `0.2.0-goodnotes`.

## Test plan

- [ ] `swift build` on Apple unchanged (CoreGraphics path still used).
- [ ] `swift build` on WASI/Linux unchanged (polyfill path still used).
- [ ] Android build of `CanvasKit/CanvasKitAndroid` Demo now succeeds with `SVGToNotesItems` linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)