### PR TITLE
[CPF] Use tagged Xylem release

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -12,9 +12,10 @@
     {
       "identity" : "xylem",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/compnerd/xylem.git",
+      "location" : "https://github.com/GoodNotes/xylem.git",
       "state" : {
-        "revision" : "9881c95ce3a139f4ccfa584676201516c2a5751d"
+        "revision" : "9881c95ce3a139f4ccfa584676201516c2a5751d",
+        "version" : "0.1.0-goodnotes-foundation-essentials"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,8 @@ let package = Package(
             from: "1.5.0"
         ),
         .package(
-            url: "https://github.com/compnerd/xylem.git",
-            revision: "9881c95ce3a139f4ccfa584676201516c2a5751d"
+            url: "https://github.com/GoodNotes/xylem.git",
+            exact: "0.1.0-goodnotes-foundation-essentials"
         ),
     ],
     targets: [


### PR DESCRIPTION
## What is the goal?
Allow versioned SVGView releases to resolve through SwiftPM.

## How is it being implemented?
- Depend on `GoodNotes/xylem` `0.1.0-goodnotes-foundation-essentials` instead of an upstream revision.
- Preserve the tested Xylem commit in `Package.resolved`.

## Testing
- `swift package resolve`
- Versioned consumer resolution
- `swift test --filter SVGParsingUtilitiesTests`
- `swift test --filter DOMParserTests`
- Wasm release build