### PR TITLE
[CPF] Reuse Foundation geometry on WASI

### DIFF
--- a/Source/CoreGraphicsPolyfill.swift
+++ b/Source/CoreGraphicsPolyfill.swift
@@ -5,7 +5,7 @@
 //  Created by khoi on 10/5/25.
 //
 
-#if os(Linux)
+#if os(Linux) || os(WASI)
 import Foundation
 #elseif canImport(FoundationEssentials)
 import FoundationEssentials
@@ -19,7 +19,7 @@ import WASILibc
 import Glibc
 #endif
 
-#if os(Linux)
+#if os(Linux) || os(WASI)
 public typealias CGFloat = Foundation.CGFloat
 public typealias CGPoint = Foundation.CGPoint
 public typealias CGSize = Foundation.CGSize

--- a/Source/Serialization/Serializations.swift
+++ b/Source/Serialization/Serializations.swift
@@ -49,7 +49,7 @@ extension CGFloat: SerializableAtom {
 
 }
 
-#if canImport(CoreGraphics) || os(Linux)
+#if canImport(CoreGraphics) || os(Linux) || os(WASI)
 extension Double: SerializableAtom {
 
     func serialize() -> String {

--- a/Tests/CoreGraphicsPolyfillTests/PolyfillTests.swift
+++ b/Tests/CoreGraphicsPolyfillTests/PolyfillTests.swift
@@ -16,6 +16,7 @@
 //  since the polyfill types are aliases to the native CoreGraphics types.
 //
 
+import Foundation
 import XCTest
 
 @testable import SVGView
@@ -23,6 +24,17 @@ import XCTest
 final class PolyfillTests: XCTestCase {
     
     #if os(WASI) || os(Linux) || os(Android)
+
+    #if os(WASI) || os(Linux)
+    func testGeometryTypesMatchFoundation() {
+        let scalar: Foundation.CGFloat = CGFloat(1)
+        let point: Foundation.CGPoint = CGPoint(x: scalar, y: scalar)
+        let size: Foundation.CGSize = CGSize(width: scalar, height: scalar)
+        let rect: Foundation.CGRect = CGRect(origin: point, size: size)
+
+        XCTAssertEqual(rect, Foundation.CGRect(x: 1, y: 1, width: 1, height: 1))
+    }
+    #endif
     
     // MARK: - CGAffineTransform Tests
     


### PR DESCRIPTION
## What is the goal?
Prevent ambiguous `CGFloat`, `CGPoint`, `CGSize`, and `CGRect` lookups when WASI consumers import both Foundation and SVGView.

## How is it being implemented?
- Reuse Foundation geometry types on WASI.
- Keep `Double` serialization available after `CGFloat` becomes Foundation-backed.
- Verify Foundation and SVGView expose the same geometry types.

## Testing
- `swift test --filter CoreGraphicsPolyfillTests`
- WASI consumer build importing Foundation and SVGView
- `swift format lint` on changed files