### PR TITLE
[CPF] Use Android C library imports

### DIFF
--- a/Source/CoreGraphicsPolyfill.swift
+++ b/Source/CoreGraphicsPolyfill.swift
@@ -15,7 +15,9 @@ import Foundation
 
 #if os(WASI)
 import WASILibc
-#elseif os(Linux) || os(Android)
+#elseif canImport(Android)
+import Android
+#elseif canImport(Glibc)
 import Glibc
 #endif
 

--- a/Source/Model/Primitives/SVGGradient.swift
+++ b/Source/Model/Primitives/SVGGradient.swift
@@ -15,7 +15,9 @@ import Foundation
 
 #if os(WASI)
 import WASILibc
-#elseif os(Linux) || os(Android)
+#elseif canImport(Android)
+import Android
+#elseif canImport(Glibc)
 import Glibc
 #endif
 

--- a/Source/Parser/SVG/Primitives/SVGLengthParser.swift
+++ b/Source/Parser/SVG/Primitives/SVGLengthParser.swift
@@ -13,7 +13,9 @@ import Foundation
 
 #if os(WASI)
 import WASILibc
-#elseif os(Linux) || os(Android)
+#elseif canImport(Android)
+import Android
+#elseif canImport(Glibc)
 import Glibc
 #endif
 

--- a/Source/Parser/SVG/SVGParserPrimitives.swift
+++ b/Source/Parser/SVG/SVGParserPrimitives.swift
@@ -15,7 +15,9 @@ import Foundation
 
 #if os(WASI)
 import WASILibc
-#elseif os(Linux) || os(Android)
+#elseif canImport(Android)
+import Android
+#elseif canImport(Glibc)
 import Glibc
 #endif
 

--- a/Source/Parser/SVG/SVGPathReader.swift
+++ b/Source/Parser/SVG/SVGPathReader.swift
@@ -15,7 +15,9 @@ public typealias MBezierPath = UIBezierPath
 import FoundationEssentials
 #if os(WASI)
 import WASILibc
-#elseif os(Linux) || os(Android)
+#elseif canImport(Android)
+import Android
+#elseif canImport(Glibc)
 import Glibc
 #endif
 #elseif os(WASI) || os(Linux) || os(Android)


### PR DESCRIPTION
## What is the goal?
Fix SVGView compilation with the GoodNotes Android Swift toolchain, which does not provide a Glibc module.

## How is it being implemented?
- Import Android when that module is available.
- Fall back to Glibc by capability on Linux.
- Preserve the explicit WASILibc branch.

## Testing
- `swift test` (154 tests)
- WASI release build with the matching Swift 6.5 toolchain and SDK