### PR TITLE
[CPF] Reuse Foundation geometry on Android

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,46 @@ jobs:
       - name: Run tests
         run: swift test --filter CoreGraphicsPolyfillTests
 
+  build-android:
+    name: Build for Android
+    runs-on: ubuntu-22.04
+    env:
+      ANDROID_NDK_VERSION: "28.2.13676358"
+      ANDROID_SWIFT_SDK_URL: "https://download.swift.org/swift-6.3.1-release/android-sdk/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE_android.artifactbundle.tar.gz"
+      ANDROID_SWIFT_SDK_CHECKSUM: "8193a4e96538635131a154736c8896fba0e5a1c30e065524f00ed78719bac35a"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Swift
+        uses: swift-actions/setup-swift@v3
+        with:
+          swift-version: "6.3.1"
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
+        with:
+          packages: ""
+
+      - name: Install Android NDK
+        run: sdkmanager "ndk;${ANDROID_NDK_VERSION}"
+
+      - name: Install Swift Android SDK
+        run: |
+          swift sdk install \
+            "$ANDROID_SWIFT_SDK_URL" \
+            --checksum "$ANDROID_SWIFT_SDK_CHECKSUM"
+
+      - name: Configure Swift Android SDK
+        run: |
+          swift_sdk_root="$HOME/.swiftpm/swift-sdks/swift-6.3.1-RELEASE_android.artifactbundle/swift-android"
+          ANDROID_NDK_HOME="$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION" \
+            bash "$swift_sdk_root/scripts/setup-android-sdk.sh"
+
+      - name: Build for Android
+        run: swift build --target SVGView --swift-sdk aarch64-unknown-linux-android31
+
   test-macos:
     name: Test on macOS
     runs-on: macos-26

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       ANDROID_NDK_VERSION: "28.2.13676358"
+      ANDROID_SWIFT_TOOLCHAIN_URL: "https://download.swift.org/swift-6.3.1-release/ubuntu2204/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE-ubuntu22.04.tar.gz"
       ANDROID_SWIFT_SDK_URL: "https://download.swift.org/swift-6.3.1-release/android-sdk/swift-6.3.1-RELEASE/swift-6.3.1-RELEASE_android.artifactbundle.tar.gz"
       ANDROID_SWIFT_SDK_CHECKSUM: "8193a4e96538635131a154736c8896fba0e5a1c30e065524f00ed78719bac35a"
 
@@ -32,10 +33,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Setup Swift
-        uses: swift-actions/setup-swift@v3
+      - name: Install Swift
+        run: |
+          swift_archive="$RUNNER_TEMP/swift-6.3.1.tar.gz"
+          swift_root="$RUNNER_TEMP/swift-6.3.1"
+          curl --fail --location --retry 3 \
+            --output "$swift_archive" \
+            "$ANDROID_SWIFT_TOOLCHAIN_URL"
+          mkdir -p "$swift_root"
+          tar -xzf "$swift_archive" -C "$swift_root" --strip-components=1
+          echo "$swift_root/usr/bin" >> "$GITHUB_PATH"
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00
         with:
-          swift-version: "6.3.1"
+          distribution: temurin
+          java-version: "17"
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
@@ -53,9 +66,14 @@ jobs:
 
       - name: Configure Swift Android SDK
         run: |
-          swift_sdk_root="$HOME/.swiftpm/swift-sdks/swift-6.3.1-RELEASE_android.artifactbundle/swift-android"
+          swift_setup_script="$(
+            find "$HOME" \
+              -path "*/swift-sdks/*/swift-android/scripts/setup-android-sdk.sh" \
+              -print -quit
+          )"
+          test -n "$swift_setup_script"
           ANDROID_NDK_HOME="$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION" \
-            bash "$swift_sdk_root/scripts/setup-android-sdk.sh"
+            bash "$swift_setup_script"
 
       - name: Build for Android
         run: swift build --target SVGView --swift-sdk aarch64-unknown-linux-android31

--- a/Source/CoreGraphicsPolyfill.swift
+++ b/Source/CoreGraphicsPolyfill.swift
@@ -5,7 +5,7 @@
 //  Created by khoi on 10/5/25.
 //
 
-#if os(Linux) || os(WASI)
+#if os(Linux) || os(WASI) || os(Android)
 import Foundation
 #elseif canImport(FoundationEssentials)
 import FoundationEssentials
@@ -21,7 +21,7 @@ import Android
 import Glibc
 #endif
 
-#if os(Linux) || os(WASI)
+#if os(Linux) || os(WASI) || os(Android)
 public typealias CGFloat = Foundation.CGFloat
 public typealias CGPoint = Foundation.CGPoint
 public typealias CGSize = Foundation.CGSize

--- a/Source/Serialization/Serializations.swift
+++ b/Source/Serialization/Serializations.swift
@@ -49,7 +49,7 @@ extension CGFloat: SerializableAtom {
 
 }
 
-#if canImport(CoreGraphics) || os(Linux) || os(WASI)
+#if canImport(CoreGraphics) || os(Linux) || os(WASI) || os(Android)
 extension Double: SerializableAtom {
 
     func serialize() -> String {

--- a/Tests/CoreGraphicsPolyfillTests/PolyfillTests.swift
+++ b/Tests/CoreGraphicsPolyfillTests/PolyfillTests.swift
@@ -25,7 +25,6 @@ final class PolyfillTests: XCTestCase {
     
     #if os(WASI) || os(Linux) || os(Android)
 
-    #if os(WASI) || os(Linux)
     func testGeometryTypesMatchFoundation() {
         let scalar: Foundation.CGFloat = CGFloat(1)
         let point: Foundation.CGPoint = CGPoint(x: scalar, y: scalar)
@@ -34,7 +33,10 @@ final class PolyfillTests: XCTestCase {
 
         XCTAssertEqual(rect, Foundation.CGRect(x: 1, y: 1, width: 1, height: 1))
     }
-    #endif
+
+    func testDoubleSerialization() {
+        XCTAssertEqual(Double(1).serialize(), "1")
+    }
     
     // MARK: - CGAffineTransform Tests
     


### PR DESCRIPTION
## What is the goal?
Prevent ambiguous geometry lookups when Android consumers import Foundation and SVGView.

## How is it being implemented?
- Import Foundation and reuse its geometry types on Android.
- Keep Double serialization available after CGFloat becomes Foundation-backed.
- Run the existing Foundation identity regression on Android.

## Testing
- `swift test` (154 tests)
- WASI release build with the matching Swift 6.5 toolchain and SDK
- `swift format lint` on changed files