### PR TITLE
[CPF] Use pure-Swift CG geometry on WASI/Linux/Android

### DIFF
--- a/Source/CoreGraphicsPolyfill.swift
+++ b/Source/CoreGraphicsPolyfill.swift
@@ -5,9 +5,7 @@
 //  Created by khoi on 10/5/25.
 //
 
-#if os(Linux) || os(WASI) || os(Android)
-import Foundation
-#elseif canImport(FoundationEssentials)
+#if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
 import Foundation
@@ -21,12 +19,7 @@ import Android
 import Glibc
 #endif
 
-#if os(Linux) || os(WASI) || os(Android)
-public typealias CGFloat = Foundation.CGFloat
-public typealias CGPoint = Foundation.CGPoint
-public typealias CGSize = Foundation.CGSize
-public typealias CGRect = Foundation.CGRect
-#elseif !canImport(CoreGraphics)
+#if !canImport(CoreGraphics)
 public typealias CGFloat = Double
 
 public struct CGPoint: Equatable {

--- a/Source/Serialization/Serializations.swift
+++ b/Source/Serialization/Serializations.swift
@@ -49,7 +49,7 @@ extension CGFloat: SerializableAtom {
 
 }
 
-#if canImport(CoreGraphics) || os(Linux) || os(WASI) || os(Android)
+#if canImport(CoreGraphics)
 extension Double: SerializableAtom {
 
     func serialize() -> String {

--- a/Tests/CoreGraphicsPolyfillTests/PolyfillTests.swift
+++ b/Tests/CoreGraphicsPolyfillTests/PolyfillTests.swift
@@ -16,7 +16,20 @@
 //  since the polyfill types are aliases to the native CoreGraphics types.
 //
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
+
+#if os(WASI)
+import WASILibc
+#elseif canImport(Android)
+import Android
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
 import XCTest
 
 @testable import SVGView

--- a/Tests/CoreGraphicsPolyfillTests/PolyfillTests.swift
+++ b/Tests/CoreGraphicsPolyfillTests/PolyfillTests.swift
@@ -25,15 +25,6 @@ final class PolyfillTests: XCTestCase {
     
     #if os(WASI) || os(Linux) || os(Android)
 
-    func testGeometryTypesMatchFoundation() {
-        let scalar: Foundation.CGFloat = CGFloat(1)
-        let point: Foundation.CGPoint = CGPoint(x: scalar, y: scalar)
-        let size: Foundation.CGSize = CGSize(width: scalar, height: scalar)
-        let rect: Foundation.CGRect = CGRect(origin: point, size: size)
-
-        XCTAssertEqual(rect, Foundation.CGRect(x: 1, y: 1, width: 1, height: 1))
-    }
-
     func testDoubleSerialization() {
         XCTAssertEqual(Double(1).serialize(), "1")
     }

--- a/Tests/CoreGraphicsPolyfillTests/PolyfillTests.swift
+++ b/Tests/CoreGraphicsPolyfillTests/PolyfillTests.swift
@@ -35,8 +35,13 @@ import XCTest
 @testable import SVGView
 
 final class PolyfillTests: XCTestCase {
-    
+
     #if os(WASI) || os(Linux) || os(Android)
+
+    private typealias CGFloat = SVGView.CGFloat
+    private typealias CGPoint = SVGView.CGPoint
+    private typealias CGSize = SVGView.CGSize
+    private typealias CGRect = SVGView.CGRect
 
     func testDoubleSerialization() {
         XCTAssertEqual(Double(1).serialize(), "1")


### PR DESCRIPTION
## What is the goal?
Stop importing full Foundation for CG geometry types on WASI/Linux/Android — that import reintroduces the ICU/Foundation payload the FoundationEssentials migration is trying to remove from the Wasm link closure.

## How is it being implemented?
- Revert the CGFloat/CGPoint/CGSize/CGRect aliasing to Foundation's types on Linux/WASI/Android; use the existing pure-Swift structs instead (the same fallback already used on other platforms without CoreGraphics).
- Use canImport(FoundationEssentials) uniformly for the import instead of special-casing Linux/WASI/Android to full Foundation.
- Remove testGeometryTypesMatchFoundation, which asserted bit-for-bit equivalence with Foundation's geometry types and no longer holds now that these are distinct local types.

## Testing
- swift build (native macOS)
- swift test --filter PolyfillTests (native macOS)